### PR TITLE
Handle text inputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist/
 
 # temporary files
 *.swp
+*.orig
 
 
 # Created by https://www.gitignore.io/api/linux,osx,windows

--- a/elm-package.json
+++ b/elm-package.json
@@ -9,7 +9,8 @@
     "exposed-modules": [],
     "dependencies": {
         "elm-lang/core": "5.1.1 <= v < 6.0.0",
-        "elm-lang/html": "2.0.0 <= v < 3.0.0"
+        "elm-lang/html": "2.0.0 <= v < 3.0.0",
+        "elm-lang/dom": "1.1.1 <= v < 2.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/main.elm
+++ b/main.elm
@@ -2,7 +2,7 @@ module Main exposing (..)
 
 import Html exposing (Html, Attribute, div, span, input, text)
 import Html.Attributes exposing (..)
-import Html.Events exposing (on)
+import Html.Events exposing (on, onInput)
 import Json.Decode as Decode
 
 
@@ -17,12 +17,15 @@ main =
 
 type alias Model =
     { location : Coord
+    , text : String
     }
 
 
 model : Model
 model =
-    { location = ( 0, 0 ) }
+    { location = ( 0, 0 )
+    , text = ""
+    }
 
 
 
@@ -39,6 +42,7 @@ type alias Coord =
 
 type Msg
     = ClickAt Coord
+    | TypeText String
 
 
 update : Msg -> Model -> Model
@@ -46,6 +50,9 @@ update msg model =
     case msg of
         ClickAt ( x, y ) ->
             { model | location = ( x, y ) }
+
+        TypeText text ->
+            { model | text = text }
 
 
 
@@ -62,7 +69,15 @@ view model =
             [ class "writing"
             , stylePosition model.location
             ]
-            [ cursor, text " Will write here" ]
+            [ text model.text, cursor ]
+          -- test
+        , input
+            [ class "hide"
+            , autofocus True
+            , value model.text
+            , onInput TypeText
+            ]
+            []
         ]
 
 

--- a/main.elm
+++ b/main.elm
@@ -59,7 +59,7 @@ type Msg
     | TypeText String
     | BreakLine
     | InputBlurred
-    | Nothing
+    | NoOp
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
@@ -87,14 +87,14 @@ update msg model =
         InputBlurred ->
             ( model, focusInput )
 
-        Nothing ->
+        NoOp ->
             ( model, Cmd.none )
 
 
 focusInput : Cmd Msg
 focusInput =
     Dom.focus "hidden-input"
-        |> Task.attempt (always Nothing)
+        |> Task.attempt (always NoOp)
 
 
 

--- a/style.css
+++ b/style.css
@@ -15,7 +15,7 @@
     display: inline-block;
     vertical-align: text-top;
     width: 0.1em;
-    height: 1em;
+    height: 1em; /* a whole character height */
     background-color: #515151;
 }
 
@@ -43,4 +43,12 @@
     0% { opacity:1; }
     50% { opacity:0; }
     100% { opacity:1; }
+}
+
+.hide {
+    position: absolute;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    height: 1px; width: 1px;
+    margin: -1px; padding: 0; border: 0;
 }

--- a/style.css
+++ b/style.css
@@ -45,7 +45,7 @@
     100% { opacity:1; }
 }
 
-.hide {
+#hidden-input {
     position: absolute;
     overflow: hidden;
     clip: rect(0 0 0 0);


### PR DESCRIPTION
Fix #4 

Uses a hidden input, that we keep focused at all time, to receive the user's input.
Displays the typed text before the cursor.